### PR TITLE
Enable different colors for oscilloscope channels

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -203,7 +203,9 @@ lmms--gui--GroupBox {
 lmms--gui--Oscilloscope {
 	background: none;
 	border: none;
-	qproperty-normalColor: rgb(71, 253, 133);
+	qproperty-leftChannelColor: rgb(71, 253, 133);
+	qproperty-rightChannelColor: rgb(238, 253, 71);
+	qproperty-otherChannelsColor: rgb(71, 235, 253);
 	qproperty-clippingColor: rgb(255, 64, 64);
 }
 

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -234,7 +234,9 @@ lmms--gui--GroupBox {
 lmms--gui--Oscilloscope {
 	background: none;
 	border: none;
-	qproperty-normalColor: rgb(71, 253, 133);
+	qproperty-leftChannelColor: rgb(71, 253, 133);
+	qproperty-rightChannelColor: rgb(238, 253, 71);
+	qproperty-otherChannelsColor: rgb(71, 235, 253);
 	qproperty-clippingColor: rgb(255, 64, 64);
 }
 

--- a/include/Oscilloscope.h
+++ b/include/Oscilloscope.h
@@ -38,7 +38,9 @@ class Oscilloscope : public QWidget
 {
 	Q_OBJECT
 public:
-	Q_PROPERTY( QColor normalColor READ normalColor WRITE setNormalColor )
+	Q_PROPERTY( QColor leftChannelColor READ leftChannelColor WRITE setLeftChannelColor )
+	Q_PROPERTY( QColor rightChannelColor READ rightChannelColor WRITE setRightChannelColor )
+	Q_PROPERTY( QColor otherChannelsColor READ otherChannelsColor WRITE setOtherChannelsColor )
 	Q_PROPERTY( QColor clippingColor READ clippingColor WRITE setClippingColor )
 
 	Oscilloscope( QWidget * _parent );
@@ -46,8 +48,14 @@ public:
 
 	void setActive( bool _active );
 
-	QColor const & normalColor() const;
-	void setNormalColor(QColor const & normalColor);
+	QColor const & leftChannelColor() const;
+	void setLeftChannelColor(QColor const & leftChannelColor);
+
+	QColor const & rightChannelColor() const;
+	void setRightChannelColor(QColor const & rightChannelColor);
+
+	QColor const & otherChannelsColor() const;
+	void setOtherChannelsColor(QColor const & otherChannelsColor);
 
 	QColor const & clippingColor() const;
 	void setClippingColor(QColor const & clippingColor);
@@ -62,7 +70,7 @@ protected slots:
 	void updateAudioBuffer( const lmms::surroundSampleFrame * buffer );
 
 private:
-	QColor const & determineLineColor(float level) const;
+	bool clips(float level) const;
 
 private:
 	QPixmap m_background;
@@ -71,7 +79,9 @@ private:
 	sampleFrame * m_buffer;
 	bool m_active;
 
-	QColor m_normalColor;
+	QColor m_leftChannelColor;
+	QColor m_rightChannelColor;
+	QColor m_otherChannelsColor;
 	QColor m_clippingColor;
 } ;
 


### PR DESCRIPTION
Enable to set different colors for the oscilloscope channels:
* Left channel color
* Right channel color
* Color of all other channels

The clipping color is now used per channel, i.e. if the left channel clips but the right does not then only the signal of the left channel is painted in the clipping color.

Enable setting the colors in the style sheets and adjust the style sheets of the default and classic theme accordingly.